### PR TITLE
News importer + news template

### DIFF
--- a/templates/news/news.css
+++ b/templates/news/news.css
@@ -1,0 +1,41 @@
+.news-template {
+    p {
+        margin-bottom: 1em;
+    }
+
+    table {
+        width: 100%;
+    }
+
+    h2 a{
+        color: #535353 !important;
+        text-decoration: underline;
+    }
+
+    h1 {
+        text-transform: uppercase;
+    }
+
+    p a {
+        text-decoration: underline;
+    }
+
+    ul {
+        padding-left: unset;
+        list-style: none;
+    }
+
+    .news-collection a{
+        color: #616161
+    }
+
+    .inline-heading {
+        color: #00ccff;
+    }
+}
+
+.table-header {
+    text-decoration: underline;
+}
+
+

--- a/templates/news/news.js
+++ b/templates/news/news.js
@@ -1,0 +1,76 @@
+import {a, h2, img, strong} from "../../scripts/dom-helpers.js";
+import getPathSegments from "../../scripts/utils.js";
+import {loadTemplate} from "../../scripts/scripts.js";
+
+const newsNavInfo = [
+    { code: 'en', label: 'News', link: '/en/news' },
+    { code: 'nl', label: 'NIEUWS', link: '/nl/nieuws' },
+    { code: 'de', label: 'NACHRICHTEN', link: '/de/nachrichten' },
+    { code: 'fr', label: 'NOUVELLES', link: '/fr/nouvelles' },
+    { code: 'it', label: 'NOVITÀ', link: '/it/novita' },
+    { code: 'es', label: 'NOTICIA', link: '/es/noticia' }
+];
+
+function isTextContentUppercase(text) {
+    return /^[A-Z,\-\s]+$/.test(text);
+}
+
+function fixHeadings(main) {
+    const content = main.querySelectorAll('p strong');
+    if (content) {
+        content.forEach((el) => {
+            if (isTextContentUppercase(el.textContent)) {
+                el.classList.add('inline-heading');
+            }
+        });
+    }
+}
+
+export default async function decorate(doc) {
+
+    const [locale] = getPathSegments();
+    let label, link;
+    try {
+        ({label, link} = newsNavInfo.find(newsNav => newsNav.code === locale));
+    } catch (e) {
+        console.log(`Unsupported locale found for news article`)
+    }
+
+    const newsLink = h2({ class: 'news-collection' });
+    const newsRef = a({ href: link });
+    newsRef.textContent = label;
+    newsLink.appendChild(newsRef);
+
+    const mainDiv = doc.querySelector('div:first-of-type div');
+    mainDiv.classList.add('news-template')
+    mainDiv.insertBefore(newsLink, mainDiv.firstChild)
+
+    // Handle Brochure Links
+    const brochureEls = doc.querySelectorAll('.button-container')
+    brochureEls.forEach((brochureEl) => {
+        const brochureLinks = brochureEl.querySelectorAll('a');
+        brochureLinks.forEach((brochureLink) => {
+            brochureLink.classList.add('brochure-link');
+            brochureLink.classList.remove('button');
+            brochureLink.classList.remove('primary');
+            if(brochureLink.textContent.search('class=download-button') != -1) {
+                const downloadImg = img({ src: '/assets/media_1c8b3df2b3dd1c604dfe7c9689fadf4db9447b739.jpeg', alt: 'Download' });
+                brochureLink.removeAttribute('title');
+                brochureLink.replaceChildren(downloadImg);
+            }
+        });
+    })
+    fixHeadings(mainDiv);
+
+    // Boldify Tables Header
+    const tables = doc.querySelectorAll('table');
+    tables.forEach((table) => {
+        const header = table.querySelector('tr');
+        header.querySelectorAll('td').forEach((td) => {
+            const elem = strong(td.textContent.trim());
+            td.replaceChildren(elem);
+        });
+    });
+
+    await loadTemplate(doc, 'default');
+}

--- a/templates/news/news.js
+++ b/templates/news/news.js
@@ -1,76 +1,78 @@
-import {a, h2, img, strong} from "../../scripts/dom-helpers.js";
-import getPathSegments from "../../scripts/utils.js";
-import {loadTemplate} from "../../scripts/scripts.js";
+import {
+  a, h2, img, strong,
+} from '../../scripts/dom-helpers.js';
+import getPathSegments from '../../scripts/utils.js';
+import { loadTemplate } from '../../scripts/scripts.js';
 
 const newsNavInfo = [
-    { code: 'en', label: 'News', link: '/en/news' },
-    { code: 'nl', label: 'NIEUWS', link: '/nl/nieuws' },
-    { code: 'de', label: 'NACHRICHTEN', link: '/de/nachrichten' },
-    { code: 'fr', label: 'NOUVELLES', link: '/fr/nouvelles' },
-    { code: 'it', label: 'NOVITÀ', link: '/it/novita' },
-    { code: 'es', label: 'NOTICIA', link: '/es/noticia' }
+  { code: 'en', label: 'News', link: '/en/news' },
+  { code: 'nl', label: 'NIEUWS', link: '/nl/nieuws' },
+  { code: 'de', label: 'NACHRICHTEN', link: '/de/nachrichten' },
+  { code: 'fr', label: 'NOUVELLES', link: '/fr/nouvelles' },
+  { code: 'it', label: 'NOVITÀ', link: '/it/novita' },
+  { code: 'es', label: 'NOTICIA', link: '/es/noticia' },
 ];
 
 function isTextContentUppercase(text) {
-    return /^[A-Z,\-\s]+$/.test(text);
+  return /^[A-Z,\-\s]+$/.test(text);
 }
 
 function fixHeadings(main) {
-    const content = main.querySelectorAll('p strong');
-    if (content) {
-        content.forEach((el) => {
-            if (isTextContentUppercase(el.textContent)) {
-                el.classList.add('inline-heading');
-            }
-        });
-    }
+  const content = main.querySelectorAll('p strong');
+  if (content) {
+    content.forEach((el) => {
+      if (isTextContentUppercase(el.textContent)) {
+        el.classList.add('inline-heading');
+      }
+    });
+  }
 }
 
 export default async function decorate(doc) {
+  const [locale] = getPathSegments();
+  let label; let
+    link;
+  try {
+    ({ label, link } = newsNavInfo.find((newsNav) => newsNav.code === locale));
+  } catch (e) {
+    console.log('Unsupported locale found for news article');
+  }
 
-    const [locale] = getPathSegments();
-    let label, link;
-    try {
-        ({label, link} = newsNavInfo.find(newsNav => newsNav.code === locale));
-    } catch (e) {
-        console.log(`Unsupported locale found for news article`)
-    }
+  const newsLink = h2({ class: 'news-collection' });
+  const newsRef = a({ href: link });
+  newsRef.textContent = label;
+  newsLink.appendChild(newsRef);
 
-    const newsLink = h2({ class: 'news-collection' });
-    const newsRef = a({ href: link });
-    newsRef.textContent = label;
-    newsLink.appendChild(newsRef);
+  const mainDiv = doc.querySelector('div:first-of-type div');
+  mainDiv.classList.add('news-template');
+  mainDiv.insertBefore(newsLink, mainDiv.firstChild);
 
-    const mainDiv = doc.querySelector('div:first-of-type div');
-    mainDiv.classList.add('news-template')
-    mainDiv.insertBefore(newsLink, mainDiv.firstChild)
-
-    // Handle Brochure Links
-    const brochureEls = doc.querySelectorAll('.button-container')
-    brochureEls.forEach((brochureEl) => {
-        const brochureLinks = brochureEl.querySelectorAll('a');
-        brochureLinks.forEach((brochureLink) => {
-            brochureLink.classList.add('brochure-link');
-            brochureLink.classList.remove('button');
-            brochureLink.classList.remove('primary');
-            if(brochureLink.textContent.search('class=download-button') != -1) {
-                const downloadImg = img({ src: '/assets/media_1c8b3df2b3dd1c604dfe7c9689fadf4db9447b739.jpeg', alt: 'Download' });
-                brochureLink.removeAttribute('title');
-                brochureLink.replaceChildren(downloadImg);
-            }
-        });
-    })
-    fixHeadings(mainDiv);
-
-    // Boldify Tables Header
-    const tables = doc.querySelectorAll('table');
-    tables.forEach((table) => {
-        const header = table.querySelector('tr');
-        header.querySelectorAll('td').forEach((td) => {
-            const elem = strong(td.textContent.trim());
-            td.replaceChildren(elem);
-        });
+  // Handle Brochure Links
+  const brochureEls = doc.querySelectorAll('.button-container');
+  brochureEls.forEach((brochureEl) => {
+    const brochureLinks = brochureEl.querySelectorAll('a');
+    brochureLinks.forEach((brochureLink) => {
+      brochureLink.classList.add('brochure-link');
+      brochureLink.classList.remove('button');
+      brochureLink.classList.remove('primary');
+      if (brochureLink.textContent.search('class=download-button') !== -1) {
+        const downloadImg = img({ src: '/assets/media_1c8b3df2b3dd1c604dfe7c9689fadf4db9447b739.jpeg', alt: 'Download' });
+        brochureLink.removeAttribute('title');
+        brochureLink.replaceChildren(downloadImg);
+      }
     });
+  });
+  fixHeadings(mainDiv);
 
-    await loadTemplate(doc, 'default');
+  // Boldify Tables Header
+  const tables = doc.querySelectorAll('table');
+  tables.forEach((table) => {
+    const header = table.querySelector('tr');
+    header.querySelectorAll('td').forEach((td) => {
+      const elem = strong(td.textContent.trim());
+      td.replaceChildren(elem);
+    });
+  });
+
+  await loadTemplate(doc, 'default');
 }

--- a/tools/importer/import-news.js
+++ b/tools/importer/import-news.js
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* global WebImporter */
+
+import {
+    createMetadata,
+} from './utils.js';
+
+/**
+ * Prefixes relative links with the target domain
+ * @param {HTMLDocument} document The document
+ */
+function fixRelativeLinks(document) {
+    document.querySelectorAll('a').forEach((a) => {
+        const targetDomain = 'https://main--octoral--aemsites.hlx.page';
+        const url = new URL(a.href);
+        if(url.pathname) {
+            a.href = targetDomain + url.pathname;
+        }
+    });
+}
+
+function fixBrochure(main) {
+    const newsArticle = main.querySelector('.block-newsarticle section article');
+    if(newsArticle && newsArticle.querySelector('.entry-content p img[alt="Download Button"]')) {
+        const brochureImages = newsArticle.querySelectorAll('.entry-content p img[alt="Download Button"]')
+        if(brochureImages) {
+            brochureImages.forEach((brochureImage) => {
+                const parent = brochureImage.parentNode;
+                if(parent.nodeName == 'A') {
+                    const brochureLink = parent
+                    brochureLink.textContent += "[class=download-button]"
+                }
+            });
+        }
+    }
+
+    if(newsArticle && newsArticle.querySelector('.entry-content p a[href$=".pdf"]')) {
+        const brochureLinks = newsArticle.querySelectorAll('.entry-content p a[href$=".pdf"]');
+        if(brochureLinks) {
+            brochureLinks.forEach((brochureLink) => {
+                const fileName = new URL(brochureLink.href).pathname.split('/').pop();
+                brochureLink.setAttribute('href', '/assets/' + fileName)
+            });
+        }
+    }
+}
+
+function handleTable(main, document) {
+    const temp = main.querySelectorAll('table');
+
+    temp.forEach((t) => {
+        const cells = [['table (bordered)']];
+        t.cloneNode(true).querySelectorAll('tr').forEach(row => {
+            let x = []
+            row.querySelectorAll('td').forEach(cell => {
+                x.push(cell.textContent)
+            });
+            cells.push(x)
+        });
+        const table = WebImporter.DOMUtils.createTable(cells, document);
+        t.replaceWith(table);
+    });
+}
+
+export default {
+    /**
+     * Apply DOM operations to the provided document and return
+     * the root element to be then transformed to Markdown.
+     * @param {HTMLDocument} document The document
+     * @param {string} url The url of the page imported
+     * @param {string} html The raw html (the document is cleaned up during preprocessing)
+     * @param {object} params Object containing some parameters given by the import process.
+     * @returns {HTMLElement} The root element to be transformed
+     */
+    preprocess: ({
+                     // eslint-disable-next-line no-unused-vars
+                     document, url, html, params,
+                 }) => {
+        const newsArticle = document.querySelector('.block-newsarticle section article');
+        const fields  = {};
+        let brochureLink;
+        if (newsArticle) {
+            const newsTitle = newsArticle.querySelector('h1');
+
+            fields.newsTitle = newsArticle.querySelector('h1')?.textContent.trim().toUpperCase();
+            fields.publishDateTime = newsArticle.querySelector('.entry-meta .published')?.getAttribute('title');
+            fields.publishDate = newsArticle.querySelector('.entry-meta .published')?.innerHTML.trim();
+            fields.updatedDateTime = newsArticle.querySelector('.entry-meta .updated')?.innerHTML.trim();
+
+            const paragraphs = newsArticle.querySelectorAll('.entry-content p');
+            if(newsArticle.querySelector('.entry-content p:last-of-type a') != null) {
+                brochureLink = newsArticle.querySelector('.entry-content p:last-of-type a')?.getAttribute('href');
+                fields.brochureText = newsArticle.querySelector('.entry-content p:last-of-type a')?.textContent;
+            }
+        }
+
+        if(brochureLink) {
+            /*figure if we should download PDF  in importer or write utility seperately
+            fetchNewsBrochure(brochureLink, "/pdf/" +  (new URL(brochureLink).pathname));
+            */
+        }
+        fields.template='news';
+        params.preProcessMetadata = fields;
+    },
+
+    transformDOM: ({
+                       // eslint-disable-next-line no-unused-vars
+                       document, url, html, params,
+                   }) => {
+
+        const main = document.body;
+
+        // use helper method to remove header, footer, etc.
+        WebImporter.DOMUtils.remove(main, [
+            'header',
+            'footer',
+            'noscript',
+            '#mainmenu',
+            '.consent-notification',
+            'h2',
+            '.lightbox',
+            '.entry-meta'
+        ]);
+        // create the metadata block and append it to the main element
+
+        handleTable(main, document);
+        createMetadata(main, document, params);
+        fixBrochure(main);
+        fixRelativeLinks(main);
+        return main;
+    },
+
+    /**
+     * Return a path that describes the document being transformed (file name, nesting...).
+     * The path is then used to create the corresponding Word document.
+     * @param {HTMLDocument} document The document
+     * @param {string} url The url of the page imported
+     * @param {string} html The raw html (the document is cleaned up during preprocessing)
+     * @param {object} params Object containing some parameters given by the import process.
+     * @return {string} The path
+     */
+    generateDocumentPath: ({
+                               // eslint-disable-next-line no-unused-vars
+                               document, url, html, params,
+                           }) => {
+        const { pathname } = new URL(url);
+        const initialReplace = new URL(url).pathname.replace(/\.html$/, '').replace(/\/$/, '');
+
+        console.log(`pathname: ${pathname} -> initialReplace: ${initialReplace}`);
+        return WebImporter.FileUtils.sanitizePath(initialReplace);
+    },
+}

--- a/tools/importer/import-news.js
+++ b/tools/importer/import-news.js
@@ -48,16 +48,8 @@ function fixBrochure(main) {
 
 function handleTable(main, document) {
   const temp = main.querySelectorAll('table');
-
   temp.forEach((t) => {
-    const cells = [['table (bordered)']];
-    t.cloneNode(true).querySelectorAll('tr').forEach((row) => {
-      const x = [];
-      row.querySelectorAll('td').forEach((cell) => {
-        x.push(cell.textContent);
-      });
-      cells.push(x);
-    });
+    const cells = [[t.cloneNode(true)]];
     const table = WebImporter.DOMUtils.createTable(cells, document);
     t.replaceWith(table);
   });

--- a/tools/importer/utils.js
+++ b/tools/importer/utils.js
@@ -1,31 +1,41 @@
 /* global WebImporter */
 
 export const createMetadata = (main, document, params) => {
-    const meta = {};
+  const meta = {};
 
-    const title = document.querySelector('title');
-    if (title) {
-        meta.Title = title.textContent.replace(/[\n\t]/gm, '');
+  const title = document.querySelector('title');
+  if (title) {
+    meta.Title = title.textContent.replace(/[\n\t]/gm, '');
+  }
+
+  const desc = document.querySelector('[property="og:description"]');
+  if (desc) {
+    meta.Description = desc.content;
+  }
+
+  const img = document.querySelector('[property="og:image"]');
+  if (img && img.content) {
+    const el = document.createElement('img');
+    el.src = img.content.replaceAll('https://www.octoral.com', '');
+    meta.Image = el;
+  }
+
+  if (params.preProcessMetadata && Object.keys(params.preProcessMetadata).length) {
+    Object.assign(meta, params.preProcessMetadata);
+  }
+
+  const block = WebImporter.Blocks.getMetadataBlock(document, meta);
+  main.append(block);
+
+  return meta;
+};
+
+export const fixRelativeLinks = (document) => {
+  document.querySelectorAll('a').forEach((a) => {
+    const targetDomain = 'https://main--octoral--aemsites.hlx.page';
+    const url = new URL(a.href);
+    if (url.pathname) {
+      a.href = targetDomain + url.pathname;
     }
-
-    const desc = document.querySelector('[property="og:description"]');
-    if (desc) {
-        meta.Description = desc.content;
-    }
-
-    const img = document.querySelector('[property="og:image"]');
-    if (img && img.content) {
-        const el = document.createElement('img');
-        el.src = img.content.replaceAll('https://www.octoral.com', '');
-        meta.Image = el;
-    }
-
-    if (params.preProcessMetadata && Object.keys(params.preProcessMetadata).length) {
-        Object.assign(meta, params.preProcessMetadata);
-    }
-
-    const block = WebImporter.Blocks.getMetadataBlock(document, meta);
-    main.append(block);
-
-    return meta;
+  });
 };

--- a/tools/importer/utils.js
+++ b/tools/importer/utils.js
@@ -1,0 +1,31 @@
+/* global WebImporter */
+
+export const createMetadata = (main, document, params) => {
+    const meta = {};
+
+    const title = document.querySelector('title');
+    if (title) {
+        meta.Title = title.textContent.replace(/[\n\t]/gm, '');
+    }
+
+    const desc = document.querySelector('[property="og:description"]');
+    if (desc) {
+        meta.Description = desc.content;
+    }
+
+    const img = document.querySelector('[property="og:image"]');
+    if (img && img.content) {
+        const el = document.createElement('img');
+        el.src = img.content.replaceAll('https://www.octoral.com', '');
+        meta.Image = el;
+    }
+
+    if (params.preProcessMetadata && Object.keys(params.preProcessMetadata).length) {
+        Object.assign(meta, params.preProcessMetadata);
+    }
+
+    const block = WebImporter.Blocks.getMetadataBlock(document, meta);
+    main.append(block);
+
+    return meta;
+};


### PR DESCRIPTION
- Adds importer for news - Imports News articles, PDF brochures points to /assets/{filename}.pdf. Uploading PDF to sharepoint is pending.
- Adds news template 


Fix [#20](https://github.com/aemsites/octoral/issues/20)

Test URLs:
- Before: https://main--octoral--aemsites.hlx.live/en/news/170-discover-the-ultimate-finish-with-the-universal-surfacer
- After: https://news-template--octoral--aemsites.hlx.live/en/news/170-discover-the-ultimate-finish-with-the-universal-surfacer