### PR TITLE
updates news list with new helix-query.yaml and replaces dummy data r…

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -6,6 +6,12 @@ indices:
       - /en/news/
     target: /en/news/query-index.json
     properties:
+      title:
+        select: h1
+        value: textContent(el)
       description:
         select: main > div p
         value: words(textContent(el), 0, 25)
+      publishDate:
+        select: head > meta[name="publishdatetime"]
+        value: parseTimestamp(attribute(el, "content"), "ddd, DD MMM YYYY hh:mm:ss GMT")

--- a/templates/news-list/news-list.js
+++ b/templates/news-list/news-list.js
@@ -33,7 +33,7 @@ export default async function decorate(doc) {
   $page.append($newsPage);
 
   await new ArticleList({
-    jsonPath: '/drafts/tmorris/new-dummy-data.json',
+    jsonPath: '/en/news/query-index.json',
     articleContainer: $articles,
     articleCard: $articleCard,
     articlesPerPage,


### PR DESCRIPTION
updates news list with new helix-query.yaml and replaces dummy data reference in news-list.js with index path

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Issue 21 continued: 

Test URLs:
- Before: https://main--octoral--aemsites.hlx.live/en/news/
- After: https://issue-21-continued--octoral--aemsites.hlx.live/en/news/
